### PR TITLE
add NSS

### DIFF
--- a/code/README.md
+++ b/code/README.md
@@ -13,3 +13,5 @@ WIP: [applying SAW to OpenSSL](https://github.com/benlaurie/openssl/tree/saw/pro
 [seL4](https://sel4.systems/): an L4 kernel verified with Isabelle/HOL
 
 [Verificatum](http://www.verificatum.com/index.html): verified voting stuff
+
+[NSS](https://wiki.mozilla.org/Security/CryptoEngineering/HACL*): verified crypto (HACL&ast; code) in NSS


### PR DESCRIPTION
The latest NSS release ships with  verified code from HACL*. The link is to the wiki page tracking the progress of integrating HACL* code in NSS.